### PR TITLE
DOC: Add 'omit' syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ path/to/xctool.sh \
   test -only SomeTestTarget:SomeTestClassPrefix*,SomeTestClass/testSomeMethodPrefix*
 ```
 
+Alternatively, you can omit a specific item by prefix matching for classes or test methods:
+
+```bash
+path/to/xctool.sh \
+  -workspace YourWorkspace.xcworkspace \
+  -scheme YourScheme \
+  test -omit SomeTestTarget:SomeTestClass/testSomeMethodPrefix*
+```
+
 You can also run tests against a different SDK:
 
 ```bash


### PR DESCRIPTION
1.'omit' is used for example here;
https://github.com/facebook/xctool/pull/663
2.There may be a bug/feature missing; it did not work to add a list of items with 'omit'.
